### PR TITLE
ci: typo in quality badge branch condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
   Badge:
     needs: Quality
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Create Coverage Badge
         uses: schneegans/dynamic-badges-action@v1.1.0


### PR DESCRIPTION
It was looking for a branch named master instead of main